### PR TITLE
Full-duplex pipeline & general improvements

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs-25.05> {} }:
+let
+  nativeBuildInputs = with pkgs; [
+    libgcc.lib
+  ];
+
+in
+pkgs.mkShell {
+  inherit nativeBuildInputs;
+
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath nativeBuildInputs;
+  TMPDIR = "/tmp";
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,9 @@ requires-python = '>=3.11'
 readme = 'README.md'
 license = 'MIT'
 dependencies = [
-    'anyio>=4.10.0',
+    'anyio[trio]>=4.10.0',
     'cffi>=1.17.1',
+    'colorlog>=6.9.0',
     'msgspec>=0.19.0',
     'psutil>=7.0.0',
 ]
@@ -33,7 +34,6 @@ build-backend = 'hatchling.build'
 dev = [
     'pytest>=8.4.1',
     'pytest-anyio>=0.0.0',
-    'trio>=0.30.0',
 ]
 
 [tool.ruff]

--- a/src/hotbaud/_log.py
+++ b/src/hotbaud/_log.py
@@ -1,0 +1,57 @@
+import logging
+import time
+from typing import Iterable
+
+from colorlog import ColoredFormatter
+
+
+class UTCColoredFormatter(ColoredFormatter):
+    '''
+    A ColoredFormatter that uses UTC for timestamps
+    and formats them in ISO8601 with a trailing 'Z'.
+
+    '''
+
+    # switch time converter to UTC
+    converter = time.gmtime
+
+    def formatTime(self, record, datefmt=None):
+        # If a custom datefmt is provided, defer to the base implementation
+        if datefmt:
+            return super().formatTime(record, datefmt)
+        # Otherwise, produce ISO8601 UTC with 'Z'
+        ct = self.converter(record.created)
+        t = time.strftime('%Y-%m-%dT%H:%M:%S', ct)
+        return f'{t}Z'
+
+
+def setup_logging(
+    loglevel: str = 'info',
+    silence: Iterable[str] = ('httpx', 'hypercorn'),
+) -> None:
+    # silence chatty dependencies
+    for noisy in silence:
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+    formatter = UTCColoredFormatter(
+        '%(asctime)s %(log_color)s%(levelname)s%(reset)s %(name)s: %(message)s',
+        log_colors={
+            'DEBUG': 'cyan',
+            'INFO': 'green',
+            'WARNING': 'yellow',
+            'ERROR': 'red',
+            'CRITICAL': 'bold_red',
+        },
+    )
+
+    # install single stream handler
+    root = logging.getLogger()
+
+    # avoid duplicates if called twice
+    if root.handlers:
+        root.handlers.clear()
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+    root.setLevel(loglevel.upper())

--- a/src/hotbaud/_utils.py
+++ b/src/hotbaud/_utils.py
@@ -24,18 +24,34 @@ Misc utils that don't deserve their own module (yet)
 
 '''
 
-from contextlib import contextmanager
-
 import os
-import threading
+import re
 import time
+import math
 import signal
+import random
 import inspect
+import threading
+import collections.abc as cabc
 
 from types import ModuleType
-from typing import Any, Self
+from typing import (
+    Annotated,
+    Any,
+    AsyncGenerator,
+    Iterable,
+    Mapping,
+    Self,
+    Sequence,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 from functools import partial
+from dataclasses import dataclass, field
+from contextlib import asynccontextmanager, contextmanager
 
+import anyio
 import psutil
 import msgspec
 
@@ -223,6 +239,148 @@ def namespace_for(obj: Any) -> str:
     return f'{mod.__name__}:{qual}'  # e.g. 'pathlib:Path.home'
 
 
+'''
+Helpers for automatically coercing partial arguments into msgspec Structs
+if applicable based on the function definition annotations,
+used in .experimental._worker task spec functions.
+
+'''
+
+
+def _unwrap_annot(tp: Any | None) -> Any | None:
+    if tp is None:
+        return None
+    while get_origin(tp) is Annotated:
+        tp = get_args(tp)[0]
+    return tp
+
+
+def _struct_cls(tp: Any) -> type[msgspec.Struct] | None:
+    tp = _unwrap_annot(tp)
+    if not inspect.isclass(tp):
+        return None
+    return tp if issubclass(tp, msgspec.Struct) else None
+
+
+def _seq_elem_if_struct(tp: Any) -> type[msgspec.Struct] | None:
+    tp = _unwrap_annot(tp)
+    origin = get_origin(tp)
+    if origin in (list, Sequence):
+        args = get_args(tp)
+        if len(args) == 1:
+            return _struct_cls(args[0])
+    return None
+
+
+def _varpos_elem_ann(tp: Any) -> Any | None:
+    tp = _unwrap_annot(tp)
+    origin = get_origin(tp)
+    if origin is tuple:
+        args = get_args(tp)
+        if len(args) == 2 and args[1] is Ellipsis:
+            return args[0]
+    if origin in (list, Sequence):
+        args = get_args(tp)
+        if len(args) == 1:
+            return args[0]
+    return None
+
+
+def _varkw_value_ann(tp: Any) -> Any | None:
+    tp = _unwrap_annot(tp)
+    origin = get_origin(tp)
+    if origin in (dict, Mapping):
+        args = get_args(tp)
+        if len(args) == 2:
+            return args[1]
+    return None
+
+
+def _convert_by_ann(val: Any, ann: Any) -> Any:
+    cls = _struct_cls(ann)
+    if cls is not None:
+        return msgspec.convert(val, type=cls)
+    elem = _seq_elem_if_struct(ann)
+    if elem is not None:
+        return msgspec.convert(val, type=list[elem])
+    return val
+
+
+def coerce_msgspec_bound_args(p: partial) -> partial:
+    '''
+    Given a partial, coerce any argument whose type hint annotation implies a
+    msgspec.Struct derived type, which we can use msgspec.convert on, and
+    return the new partial with coerced args.
+
+    '''
+    f = p.func
+    sig = inspect.signature(f)
+    try:
+        hints = get_type_hints(f, include_extras=True)
+    except TypeError:
+        hints = get_type_hints(f)
+
+    pos_names = [
+        prm.name
+        for prm in sig.parameters.values()
+        if prm.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    var_pos_name = next(
+        (
+            n
+            for n, prm in sig.parameters.items()
+            if prm.kind == inspect.Parameter.VAR_POSITIONAL
+        ),
+        None,
+    )
+    var_kw_name = next(
+        (
+            n
+            for n, prm in sig.parameters.items()
+            if prm.kind == inspect.Parameter.VAR_KEYWORD
+        ),
+        None,
+    )
+
+    new_args = list(p.args)
+    fixed = min(len(new_args), len(pos_names))
+    for i in range(fixed):
+        ann = hints.get(pos_names[i])
+        if ann is not None:
+            new_args[i] = _convert_by_ann(new_args[i], ann)
+
+    if var_pos_name and len(new_args) > len(pos_names):
+        elem_ann = _varpos_elem_ann(hints.get(var_pos_name))
+        if elem_ann is not None:
+            for j in range(len(pos_names), len(new_args)):
+                new_args[j] = _convert_by_ann(new_args[j], elem_ann)
+
+    new_kw = dict(p.keywords or {})
+    param_names = set(sig.parameters)
+
+    for k, v in list(new_kw.items()):
+        if k in param_names:
+            ann = hints.get(k)
+            if ann is not None:
+                new_kw[k] = _convert_by_ann(v, ann)
+        elif var_kw_name:
+            val_ann = _varkw_value_ann(hints.get(var_kw_name))
+            if val_ann is not None:
+                new_kw[k] = _convert_by_ann(v, val_ann)
+
+    return partial(f, *new_args, **new_kw)
+
+
+'''
+Out Of Memory self-reaping machinery
+
+'''
+
+# can only enable once per process group
 _reaper_enabled = False
 
 
@@ -235,6 +393,7 @@ def oom_self_reaper(kill_at_pct: float = 0.7):
     `kill_at_pct` of system memory is consumed by the process.
 
     '''
+    # prefer module scoped cache
     global _reaper_enabled
     if _reaper_enabled:
         yield
@@ -267,3 +426,241 @@ def oom_self_reaper(kill_at_pct: float = 0.7):
     t = threading.Thread(target=watchdog, daemon=True)
     t.start()
     yield
+
+
+@contextmanager
+def maybe_oom_self_reaper(kill_at_pct: float | None = None):
+    '''
+    Optional version of reaper ctx manager, useful for situations where we
+    make reaper use configurable.
+
+    '''
+    if kill_at_pct is None:
+        yield
+        return
+
+    with oom_self_reaper(kill_at_pct):
+        yield
+
+
+'''
+Disk IO usage monitor
+
+'''
+
+
+_root_dev_re = re.compile(r'^(?P<root>.+?)(?:p?\d+)?$')
+
+
+def _root_dev_name(dev_path_or_name: str) -> str:
+    name = os.path.basename(dev_path_or_name)
+    m = _root_dev_re.match(name)
+    return m.group('root') if m else name
+
+
+def resolve_devices_for_paths(paths: Iterable[str]) -> set[str]:
+    '''Map paths to underlying root device names (psutil.perdisk keys).'''
+    parts = psutil.disk_partitions(all=True)
+    norm = [(dp, dp.mountpoint.rstrip('/') + '/') for dp in parts]
+
+    devs: set[str] = set()
+    for p in map(os.path.abspath, paths):
+        cands = [dp for dp, mp in norm if p.startswith(mp)]
+        if not cands:
+            continue
+        best = max(
+            cands,
+            key=lambda dp: len(dp.mountpoint.rstrip('/') + '/'),
+        )
+        devs.add(_root_dev_name(best.device))
+    return devs
+
+
+@dataclass
+class DiskIOGauge:
+    sample: float = 0.20
+    ema_alpha: float = 0.35
+    devices: set[str] | None = None
+    _ema: float = 0.0
+    _inst: float = 0.0
+    _version: int = 0
+    _cond: anyio.Condition = field(default_factory=anyio.Condition)
+    _prev_busy: dict[str, int] = field(default_factory=dict)
+    _prev_ts: float = 0.0
+
+    def snapshot(self) -> float:
+        '''Return smoothed utilization in [0.0, 1.0].'''
+        return self._ema
+
+    async def wait_below(
+        self,
+        *,
+        high: float,
+        low: float | None = None,
+        timeout: float | None = None,
+        jitter: float = 0.15,
+    ) -> None:
+        '''Wait until EMA <= high, with optional hysteresis to low.'''
+        low = max(0.0, high - 0.20) if low is None else low
+
+        if timeout is None:
+            async with self._cond:
+                while self._ema > high:
+                    await self._cond.wait()
+                while self._ema > low:
+                    await self._cond.wait()
+        else:
+            with anyio.move_on_after(timeout) as scope:
+                async with self._cond:
+                    while self._ema > high:
+                        await self._cond.wait()
+                    while self._ema > low:
+                        await self._cond.wait()
+            if scope.cancelled_caught:
+                return
+
+        if jitter > 0:
+            await anyio.sleep(random.uniform(0.0, jitter))
+
+    async def _tick(self) -> None:
+        per = psutil.disk_io_counters(perdisk=True)
+        ts = time.perf_counter()
+
+        if not self._prev_busy:
+            self._prev_busy = {
+                k: v.busy_time
+                for k, v in per.items()
+                if hasattr(v, 'busy_time')
+            }
+            self._prev_ts = ts
+            return
+
+        dt = max(1e-6, ts - self._prev_ts)
+        prev = self._prev_busy
+        cur_busy = {
+            k: v.busy_time for k, v in per.items() if hasattr(v, 'busy_time')
+        }
+
+        keys = set(cur_busy)
+        if self.devices:
+            keys &= self.devices
+        if not keys:
+            keys = set(cur_busy)
+
+        total_busy_ms = sum(
+            max(0.0, cur_busy.get(k, 0) - prev.get(k, 0)) for k in keys
+        )
+        denom = dt * 1000.0 * max(1, len(keys))
+        inst = min(1.0, total_busy_ms / denom)
+        self._inst = inst
+
+        self._ema = self.ema_alpha * inst + (1 - self.ema_alpha) * self._ema
+
+        self._prev_busy, self._prev_ts = cur_busy, ts
+        self._version += 1
+        async with self._cond:
+            self._cond.notify_all()
+
+    async def run(
+        self,
+        *,
+        task_status=anyio.TASK_STATUS_IGNORED,
+    ) -> None:
+        '''Background loop; cancel the task group to stop.'''
+        try:
+            await self._tick()
+        except Exception:
+            pass
+        task_status.started(self)
+        while True:
+            await anyio.sleep(self.sample)
+            try:
+                await self._tick()
+            except Exception:
+                pass
+
+
+@asynccontextmanager
+async def open_io_gauge(
+    *,
+    sample: float = 0.20,
+    ema_alpha: float = 0.35,
+    paths: Iterable[str] | None = None,
+) -> AsyncGenerator[DiskIOGauge, None]:
+    '''Start/stop the sampler as a context manager.'''
+    devices = resolve_devices_for_paths(paths or []) or None
+    gauge = DiskIOGauge(sample=sample, ema_alpha=ema_alpha, devices=devices)
+    async with anyio.create_task_group() as tg:
+        await tg.start(gauge.run)
+        try:
+            yield gauge
+        finally:
+            tg.cancel_scope.cancel()
+
+
+'''
+Simple throughput measurer tool, with scrolling window and ~tau avg
+
+'''
+
+
+def _now() -> float:
+    return time.perf_counter()
+
+
+@dataclass
+class ThroughputMeter:
+    '''
+    Smooth 'last ~tau' ticks/sec via an exponential time-decay accumulator.
+
+    Idea:
+      Maintain X(t) = decayed count of events.
+      On record(n) at time t:
+         X <- X * exp(-(t - t_prev)/tau) + n
+      Instantaneous rate estimate:
+         r_hat(t) = X(t) / tau
+
+    - No window edges => much less jumpy than a hard 5s window.
+    - Naturally and smoothly decays to 0 during idle periods.
+    '''
+
+    tau_seconds: float = 5.0  # “last ~5s” feel
+    start: float = field(default_factory=_now)
+    last_t: float = field(default_factory=_now)
+    X: float = 0.0  # decayed event mass
+    total_ticks: int = 0
+
+    def _decay_to(self, t: float) -> None:
+        dt = max(0.0, t - self.last_t)
+        if dt > 0:
+            decay = math.exp(-dt / self.tau_seconds)
+            self.X *= decay
+            self.last_t = t
+
+    def record(self, n_ticks: int, t: float | None = None) -> None:
+        '''
+        Store one sample.
+
+        '''
+        t = _now() if t is None else t
+        self._decay_to(t)
+        self.X += float(n_ticks)
+        self.total_ticks += int(n_ticks)
+
+    @property
+    def rate(self) -> float:
+        '''
+        Smoothed 'last ~tau' rate in ticks/sec.
+
+        '''
+        self._decay_to(_now())
+        return self.X / self.tau_seconds
+
+    @property
+    def rate_global(self) -> float:
+        '''
+        Global ticks/sec since start.
+
+        '''
+        elapsed = max(1e-9, _now() - self.start)
+        return self.total_ticks / elapsed

--- a/src/hotbaud/experimental/_worker.py
+++ b/src/hotbaud/experimental/_worker.py
@@ -42,19 +42,22 @@ import logging
 import pkgutil
 
 from typing import Any, AsyncGenerator, Callable, Self
-from logging import Logger
+from logging import Logger, getLogger
 from functools import partial
 from contextlib import asynccontextmanager
 
 import anyio
 import msgspec
 
-from hotbaud._utils import MessageStruct, make_partial, namespace_for
+from hotbaud._utils import MessageStruct, coerce_msgspec_bound_args, make_partial, namespace_for
 from hotbaud.memchan._impl import MemoryChannel
 
 # eventualy move hotbaud.experimental.event into hotbaud.event and stop using
 # relative import
 from .event import Event
+
+
+log = getLogger(__name__)
 
 
 spec_env_var = 'HOTBAUD_WORKER_SPEC'
@@ -149,6 +152,8 @@ def worker_main() -> None:
     # mabye inject config
     if config := spec.unwrap_config():
         task.keywords['config'] = config
+
+    task = coerce_msgspec_bound_args(task)
 
     # maybe open exit event:
     # depending on the stage this worker belongs to it might need to wait on
@@ -268,14 +273,23 @@ async def run_in_worker(
 
         kwargs['pass_fds'].append(exit_fd)
 
-    async with await anyio.open_process(cmd, env=_env, **kwargs) as process:
+    async with await anyio.open_process(
+        cmd,
+        stderr=None,
+        stdout=None,
+        env=_env,
+        **kwargs
+    ) as process:
         try:
+            log.info(f'{worker_id} spawned')
             await process.wait()
 
         finally:
             # if process still running, attempt best-effort cleanup
             if process.returncode is None:
                 process.terminate()
+
+    log.info(f'{worker_id} finished run')
 
 
 if __name__ == '__main__':

--- a/src/hotbaud/experimental/pipeline.py
+++ b/src/hotbaud/experimental/pipeline.py
@@ -33,16 +33,18 @@ Meant for:
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 import os
 import enum
 import logging
 
-from typing import Any, Awaitable, Callable, Generator, Protocol, Sequence
+from typing import Any, AsyncGenerator, Awaitable, Callable, Generator, Protocol, Sequence
 from pathlib import Path
 from functools import partial
 from dataclasses import dataclass
 
 import anyio
+from hotbaud.memchan._impl import attach_to_memory_channel
 import msgspec
 
 from hotbaud.eventfd import (
@@ -56,15 +58,36 @@ from hotbaud.types import SharedMemory
 from hotbaud.memchan import (
     MCToken,
     alloc_memory_channel,
+    attach_to_memory_channel,
+    MemoryChannel
 )
 
-from hotbaud._utils import make_partial, oom_self_reaper
-from hotbaud._fdshare import fdshare_server_task, open_fd_share_socket
+from hotbaud._utils import MessageStruct, make_partial, maybe_oom_self_reaper
+from hotbaud._fdshare import fdshare_server_task
 
 from hotbaud.experimental._worker import run_in_worker
 
 
 log = logging.getLogger(__name__)
+
+
+class Port(MessageStruct, frozen=True):
+    '''
+    A worker-facing 'port': tokens in the correct orientation for this worker.
+    Use: attach_to_memory_channel(port.in_token, port.out_token)
+
+    '''
+    in_token:  MCToken  # used to RECEIVE by this worker
+    out_token: MCToken  # used to SEND by this worker
+
+    @asynccontextmanager
+    async def attach(self, **kwargs) -> AsyncGenerator[MemoryChannel, None]:
+        async with attach_to_memory_channel(
+            self.in_token,
+            self.out_token,
+            **kwargs
+        ) as channel:
+            yield channel
 
 
 class ConnectionStrategy(enum.StrEnum):
@@ -125,14 +148,17 @@ class StageDef:
 @dataclass(slots=True)
 class ChannelDef:
     '''
-    Metadata about one logical IPC memory channel.
+    A *duplex* logical link between two stages:
+      <name>.fwd : upstream -> downstream
+      <name>.bwd : downstream -> upstream
 
     '''
-
     name: str
-    shm: SharedMemory | None = None
-    token: MCToken | None = None
-    buf_size: int = 64 * 1024  # 64kb
+    shm_fwd: SharedMemory | None = None
+    tok_fwd: MCToken | None = None
+    shm_bwd: SharedMemory | None = None
+    tok_bwd: MCToken | None = None
+    buf_size: int = 64 * 1024
 
 
 class PipelineBuilder:
@@ -370,14 +396,19 @@ class PipelineBuilder:
 
         '''
         for cdef in self._channels.values():
-            key = f'{self.pipe_id}.{cdef.name}'
-            (
-                cdef.shm,
-                cdef.token,
-            ) = alloc_memory_channel(
-                key,
+            base = f'{self.pipe_id}.{cdef.name}'
+            # forward path (upstream -> downstream)
+            cdef.shm_fwd, cdef.tok_fwd = alloc_memory_channel(
+                f'{base}.fwd',
                 buf_size=cdef.buf_size,
-                share_path=str(self._socket_dir / f'{key}.sock'),
+                share_path=str(self._socket_dir / f'{base}.fwd.sock'),
+                sync_backend=self._sync_backend,
+            )
+            # backward path (downstream -> upstream)
+            cdef.shm_bwd, cdef.tok_bwd = alloc_memory_channel(
+                f'{base}.bwd',
+                buf_size=cdef.buf_size,
+                share_path=str(self._socket_dir / f'{base}.bwd.sock'),
                 sync_backend=self._sync_backend,
             )
 
@@ -396,38 +427,56 @@ class PipelineBuilder:
         workers: list[PipelineWorker] = []
 
         for sdef in self._stages:
-            # inject, depending on topology, the input and/or output token or
-            # tokens into the function's `in_token(s)` & `out_token(s)` keyword
+            # inject, depending on topology, the input and/or output port or
+            # ports into the function's `in_port(s)` & `out_port(s)` keyword
             # arguments
             for idx in range(sdef.size):
                 func = partial(sdef.func)  # fresh copy
                 kw: dict[str, Any] = {}
 
-                # input side
+                # input side (this worker is *downstream* of these links)
                 if sdef.inputs:
-                    in_toks = [self._channels[ch].token for ch in sdef.inputs]
-                    if sdef.strategy is ConnectionStrategy.MANY_TO_ONE:
-                        kw['in_tokens'] = in_toks  # N -> 1
-                    elif (
-                        sdef.strategy is ConnectionStrategy.ONE_TO_ONE
-                        and len(in_toks) >= sdef.size
-                    ):
-                        kw['in_token'] = in_toks[idx]  # 1 -> 1
-                    else:
-                        kw['in_token'] = in_toks[0]  # single input
+                    def _down_port(name: str) -> Port:
+                        ch = self._channels[name]
+                        return Port(in_token=ch.tok_fwd, out_token=ch.tok_bwd)
 
-                # output side
-                if sdef.outputs:
-                    out_toks = [self._channels[ch].token for ch in sdef.outputs]
-                    if sdef.strategy is ConnectionStrategy.ONE_TO_MANY:
-                        kw['out_tokens'] = out_toks  # 1 -> N
-                    elif (
-                        sdef.strategy is ConnectionStrategy.ONE_TO_ONE
-                        and len(out_toks) >= sdef.size
-                    ):
-                        kw['out_token'] = out_toks[idx]  # 1 -> 1
+                    in_names = list(sdef.inputs)
+                    if sdef.strategy is ConnectionStrategy.MANY_TO_ONE:
+                        in_ports = [_down_port(n) for n in in_names]  # N -> 1
+
+                    elif (sdef.strategy is ConnectionStrategy.ONE_TO_ONE
+                          and len(in_names) >= sdef.size):
+                        in_ports = [_down_port(in_names[idx])]  # 1 -> 1
+
                     else:
-                        kw['out_token'] = out_toks[0]  # single output
+                        in_ports = [_down_port(in_names[0])]  # single inputs
+
+                    if len(in_ports) == 1:
+                        kw['in_port'] = in_ports[0]
+
+                    else:
+                        kw['in_ports'] = in_ports
+
+                # output side (this worker is *upstream* of these links)
+                if sdef.outputs:
+                    def _up_port(name: str) -> Port:
+                        ch = self._channels[name]
+                        return Port(in_token=ch.tok_bwd, out_token=ch.tok_fwd)
+
+                    out_names = list(sdef.outputs)
+                    if sdef.strategy is ConnectionStrategy.ONE_TO_MANY:
+                        out_ports = [_up_port(n) for n in out_names]  # 1 -> N
+                    elif (sdef.strategy is ConnectionStrategy.ONE_TO_ONE
+                          and len(out_names) >= sdef.size):
+                        out_ports = [_up_port(out_names[idx])]  # 1 -> 1
+                    else:
+                        out_ports = [_up_port(out_names[0])]  # single output
+
+                    if len(out_ports) == 1:
+                        kw['out_port'] = out_ports[0]
+
+                    else:
+                        kw['out_ports'] = out_ports
 
                 func.keywords.update(kw)
 
@@ -543,7 +592,7 @@ class Pipeline:
         self,
         *,
         spawn_fn: WorkerSpawnFn = run_in_worker,
-        oom_reap_pct: float = 0.9,
+        oom_reap_pct: float | None = 0.9,
     ) -> None:
         '''
         Long running pipeline task.
@@ -551,18 +600,15 @@ class Pipeline:
         Start all fdshare tasks for channels that need it, then spawn stages
 
         '''
-        with oom_self_reaper(kill_at_pct=oom_reap_pct):
+        with maybe_oom_self_reaper(oom_reap_pct):
             async with anyio.create_task_group() as tg:
                 # channels with .token.share_path need a task spawned to open the
                 # socket and pass the fds to clients
                 for c in self.channels.values():
-                    assert c.token, 'Expected {c.name} to have token at this point'
-                    if c.token.share_path:
-                        tg.start_soon(
-                            fdshare_server_task,
-                            Path(c.token.share_path),
-                            c.token.fds,
-                        )
+                    for tok in (c.tok_fwd, c.tok_bwd):
+                        assert tok, f'Expected {c.name} to have tokens at this point'
+                        if tok.share_path:
+                            tg.start_soon(fdshare_server_task, Path(tok.share_path), tok.fds)
 
                 # use an inner tg in order to have separate task scopes for
                 # stage tasks & fd share tasks
@@ -589,6 +635,7 @@ class Pipeline:
 
     async def __aexit__(self, exc_type, exc, tb):
         for c in self.channels.values():
-            if c.shm is not None:
-                c.shm.close()
-                c.shm.unlink()
+            if c.shm_fwd is not None:
+                c.shm_fwd.close(); c.shm_fwd.unlink()
+            if c.shm_bwd is not None:
+                c.shm_bwd.close(); c.shm_bwd.unlink()

--- a/src/hotbaud/memchan/_fans.py
+++ b/src/hotbaud/memchan/_fans.py
@@ -30,7 +30,7 @@ from contextlib import AsyncExitStack, asynccontextmanager
 import itertools
 
 from heapq import heappush, heappop
-from typing import AsyncGenerator, AsyncIterator, Awaitable, Protocol, Sequence
+from typing import AsyncGenerator, AsyncIterator, Awaitable, Literal, Protocol, Sequence
 
 import anyio
 import msgspec
@@ -61,11 +61,15 @@ class FanOutSendFn(Protocol):
     ) -> Awaitable[None]: ...
 
 
+FanOutStrategy = Literal['turns', 'smart', 'direct']
+
+
 @asynccontextmanager
 async def attach_fan_out_sender(
     out_tokens: Sequence[MCToken],
     *,
     ordered: bool = False,
+    strategy: FanOutStrategy = 'smart'
 ) -> AsyncGenerator[FanOutSendFn, None]:
     if not out_tokens:
         raise ValueError('attach_fan_out_sender expects at least one token')
@@ -79,7 +83,14 @@ async def attach_fan_out_sender(
             for t in out_tokens
         ]
 
-        async def send(payload: Buffer, broadcast: bool = False) -> None:
+        smap = {t.shm_name: sender for t, sender in zip(out_tokens, senders)}
+
+        async def send(
+            payload: Buffer,
+            *,
+            broadcast: bool = False,
+            target: str | None = None
+        ) -> None:
             raw = (
                 OrderedMsg(index=seq(), msg=payload).encode()
                 if ordered
@@ -93,9 +104,22 @@ async def attach_fan_out_sender(
 
                 return
 
-            nonlocal rr_idx
-            sender = senders[rr_idx]
-            rr_idx = (rr_idx + 1) % len(senders)
+            match strategy:
+                case 'turns':
+                    nonlocal rr_idx
+                    sender = senders[rr_idx]
+                    rr_idx = (rr_idx + 1) % len(senders)
+
+                case 'smart':
+                    sender = min(
+                        senders,
+                        key=lambda s: s.write_ptr - s.read_ptr
+                    )
+
+                case 'direct':
+                    assert target, 'must provide target on direct mode!'
+                    sender = smap[target]
+
 
             await sender.send(raw)
 

--- a/src/hotbaud/memchan/_impl.py
+++ b/src/hotbaud/memchan/_impl.py
@@ -807,12 +807,21 @@ class MemoryChannel:
     async def receive_exactly(self, num_bytes: int) -> bytes:
         return await self._receiver.receive_exactly(num_bytes)
 
-    async def receive(self) -> bytes:
-        return await self._receiver.receive()
+    async def receive(self, raw: bool = False) -> bytes:
+        return await self._receiver.receive(raw=raw)
 
     async def aclose(self):
         await self._receiver.aclose()
         await self._sender.aclose()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        try:
+            return await self.receive(raw=True)
+        except (anyio.EndOfStream, anyio.ClosedResourceError):
+            raise StopAsyncIteration
 
 
 @acm

--- a/src/hotbaud/testing.py
+++ b/src/hotbaud/testing.py
@@ -1,17 +1,13 @@
 import time
-from hotbaud import MCToken
-from hotbaud.memchan._impl import (
-    attach_to_memory_receiver,
-    attach_to_memory_sender,
-)
+from hotbaud.experimental.pipeline import Port
 
 
 async def byte_fiend(
-    worker_id: str, in_token: MCToken, slot_size: int, msg_size: int
+    worker_id: str, in_port: Port, slot_size: int, msg_size: int, **kwargs
 ) -> None:
     slot_bytes = 0
     slot_mono = time.perf_counter()
-    async with attach_to_memory_receiver(in_token) as chan:
+    async with in_port.attach() as chan:
         async for msg in chan:
             slot_bytes += len(msg)
             if slot_bytes >= slot_size:
@@ -27,11 +23,11 @@ async def byte_fiend(
 
 
 async def byte_pusher(
-    worker_id: str, out_token: MCToken, amount_gb: int, msg_size: int
+    worker_id: str, out_port: Port, amount_gb: int, msg_size: int, **kwargs
 ) -> None:
     packet = b'1' * msg_size
     msg_amount = int((amount_gb * 1024 * 1024 * 1024) // msg_size)
     print(msg_amount)
-    async with attach_to_memory_sender(out_token) as chan:
+    async with out_port.attach() as chan:
         for _ in range(msg_amount):
             await chan.send(packet)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -12,6 +12,12 @@ from hotbaud.memchan._impl import (
     open_memory_channel,
 )
 
+pytest.mark.skip(
+    sys.platform != 'linux',
+    reason='Linux-only: relies on eventfd(2)',
+    allow_module_level=True
+)
+
 
 def sender_process(
     token: MCToken,
@@ -32,15 +38,6 @@ def receiver_process(token: MCToken) -> list[str]:
             return [msg.decode() async for msg in receiver]
 
     return anyio.run(_main, backend='trio')
-
-
-pytestmark = [
-    pytest.mark.anyio,
-    pytest.mark.skipif(
-        sys.platform != 'linux',
-        reason='Linux-only: relies on eventfd(2)',
-    ),
-]
 
 
 def _shm_name() -> str:

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from hotbaud._log import setup_logging
 from hotbaud.eventfd import EFDSyncMethods
 import pytest
 
@@ -44,6 +45,7 @@ async def test_throughput(
     builder = (
         PipelineBuilder(
             'pusher-fiend-pattern',
+            log_setup=setup_logging,
             sync_backend=sync_backend,
             share_path=tmp_path_factory.mktemp('.hotbaud'),
         )
@@ -52,12 +54,14 @@ async def test_throughput(
             partial(byte_pusher, amount_gb=amount_gb, msg_size=msg_size),
             outputs='bytes',
             out_size=buf_size,
+            async_lib='trio'
         )
         .stage(
             'fiend',
             partial(byte_fiend, slot_size=slot_size, msg_size=msg_size),
             inputs='bytes',
             in_size=buf_size,
+            async_lib='trio'
         )
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
 ]
 
+[package.optional-dependencies]
+trio = [
+    { name = "trio" },
+]
+
 [[package]]
 name = "attrs"
 version = "25.3.0"
@@ -80,12 +85,25 @@ wheels = [
 ]
 
 [[package]]
+name = "colorlog"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/7a/359f4d5df2353f26172b3cc39ea32daa39af8de522205f512f458923e677/colorlog-6.9.0.tar.gz", hash = "sha256:bfba54a1b93b94f54e1f4fe48395725a3d92fd2a4af702f6bd70946bdc0c6ac2", size = 16624, upload-time = "2024-10-29T18:34:51.011Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/51/9b208e85196941db2f0654ad0357ca6388ab3ed67efdbfc799f35d1f83aa/colorlog-6.9.0-py3-none-any.whl", hash = "sha256:5906e71acd67cb07a71e779c47c4bcb45fb8c2993eebe9e5adcd6a6f1b283eff", size = 11424, upload-time = "2024-10-29T18:34:49.815Z" },
+]
+
+[[package]]
 name = "hotbaud"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", extra = ["trio"] },
     { name = "cffi" },
+    { name = "colorlog" },
     { name = "msgspec" },
     { name = "psutil" },
 ]
@@ -94,13 +112,13 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-anyio" },
-    { name = "trio" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", specifier = ">=4.10.0" },
+    { name = "anyio", extras = ["trio"], specifier = ">=4.10.0" },
     { name = "cffi", specifier = ">=1.17.1" },
+    { name = "colorlog", specifier = ">=6.9.0" },
     { name = "msgspec", specifier = ">=0.19.0" },
     { name = "psutil", specifier = ">=7.0.0" },
 ]
@@ -109,7 +127,6 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-anyio", specifier = ">=0.0.0" },
-    { name = "trio", specifier = ">=0.30.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Channels
- Implement __aiter__ and __anext__ on MemoryChannel
- Add pass-through kwarg "raw" to MemoryChannel.receive
- Add fan out "strategies" which dictate how to pick next channel to send through:
  - 'turns': one msg each, legacy logic
  - 'smart': send the msg to the channel whose reader ptr is closest to writer ptr
  - 'direct': specify channel by shared memory name

# Experimental
- Worker:
  - Add worker task target msgspec argument coercion

- Pipeline:
  - Make full-duplex streams between stages in order for easy pull pattern

# Testing
- Update test_pipe.py::test_throughput to new anyio style PipelineBuilder args
- Update pusher-find testing workers to latest full-duplex port style API

# Misc
- Add nix-shell with libc
- Add colorlog logging setup utils
- Use anyio[trio] dep instead of anyio and trio separatly
- Add optional oom self reaper util
- Add disk IO usage monitor util
- Add throughput measure util